### PR TITLE
fixed: error when trying to slide when clicking complex object

### DIFF
--- a/projects/mat-tab-group-gesture/src/lib/mat-tab-group-gesture.directive.ts
+++ b/projects/mat-tab-group-gesture/src/lib/mat-tab-group-gesture.directive.ts
@@ -97,7 +97,8 @@ export class MatTabGroupGestureDirective implements OnInit {
     fromEvent(this.body, 'touchstart')
       .pipe(
         switchMap((e: any) => {
-          if (e.path.findIndex((p: any) => p.className && p.className.indexOf('mat-slider') > -1) > -1) { this.skipBodySwipe = true; }
+          // need to test classname to string otherwise can throw error
+          if (e.path.findIndex((p: any) => p.className && typeof p.className === 'string' && p.className.indexOf('mat-slider') > -1) > -1) { this.skipBodySwipe = true; }
           // after a mouse down, we'll record all mouse moves
           return fromEvent(this.body, 'touchmove')
             .pipe(


### PR DESCRIPTION
When clicking on complex object on tab (happened to me when clicked on SVG icon) throws error.
"p.className" was type of object, object.indexOf() is undefined